### PR TITLE
Speed up Babel + use newer version of grunt-csso.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,7 +205,8 @@ module.exports = function (grunt) {
 
         'babel': {
             options: {
-                sourceMap: true
+                sourceMap: false,
+                nonStandard: false,
             },
             dist: {
                 files: {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-contrib-copy": "~0.8.0",
     "grunt-contrib-imagemin": "~0.9.4",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-csso": "git://github.com/amyboyd/grunt-csso.git",
+    "grunt-csso": "~0.7.1",
     "grunt-sass": "~1.0.0",
     "jasmine-core": "~2.3.4",
     "jasmine-reporters": "~2.0.6",


### PR DESCRIPTION
The custom version of grunt-csso is no longer needed, because it works with our other dependency versions now.

The Babel config changes speeds JS compilation by about 0.3 seconds (on my laptop).