### PR TITLE
Add set height to vendor items on Vendors page, to prevent gaps.

### DIFF
--- a/src/web/scss/main.scss
+++ b/src/web/scss/main.scss
@@ -960,12 +960,14 @@ body {
     padding: 0 15px 15px;
     text-align: center;
     width: 50%;
+    height: 198px;
 }
 
 @media only screen and (min-width: $screen-sm-min) {
     .vendors .vendor {
         padding-bottom: 30px;
         width: 25%;
+        height: 213px;
     }
 }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4738124/7983091/cce35608-0ab4-11e5-872c-7ef4ebd47f83.png)
