### PR TITLE
Add button to get visible order numbers in admin orders page.

### DIFF
--- a/src/web/js/config.js
+++ b/src/web/js/config.js
@@ -294,7 +294,6 @@ angular.module('cp').config(function($routeProvider, $analyticsProvider, getTemp
         }).
         when('/admin/orders', {
             controller: 'AdminOrdersController',
-            controllerAs: 'orders',
             templateUrl: getTemplateUrl('admin/orders.html')
         }).
         when('/admin/order/:orderId', {

--- a/src/web/js/controllers/admin/AdminOrdersController.js
+++ b/src/web/js/controllers/admin/AdminOrdersController.js
@@ -5,8 +5,6 @@ angular.module('cp.controllers.admin').controller('AdminOrdersController',
     DocumentTitleService('Orders');
     SecurityService.requireStaff();
 
-    var vm = this;
-
     const setFiltersToSpanAllOfToday = filters => {
         const today = new Date();
 
@@ -19,7 +17,9 @@ angular.module('cp.controllers.admin').controller('AdminOrdersController',
         filters[1].term = today.toISOString();
     };
 
-    vm.gridOptions = {
+    let gridApi;
+
+    $scope.gridOptions = {
         columnDefs: [
             {
                 displayName: 'Order No',
@@ -129,7 +129,7 @@ angular.module('cp.controllers.admin').controller('AdminOrdersController',
                 row.customerUserAndCompanyName = row.customerUser.name + ', ' + row.customer.company;
             });
 
-            vm.gridOptions.data = response.orders;
+            $scope.gridOptions.data = response.orders;
 
             LoadingService.hide();
         }).error(() => NotificationService.notifyError());
@@ -137,7 +137,7 @@ angular.module('cp.controllers.admin').controller('AdminOrdersController',
 
     loadOrders();
 
-    $scope.showOrdersPlacedToday = () => setFiltersToSpanAllOfToday(this.gridOptions.columnDefs[1].filters);
+    $scope.showOrdersPlacedToday = () => setFiltersToSpanAllOfToday($scope.gridOptions.columnDefs[1].filters);
 
-    $scope.showOrdersDeliveredToday = () => setFiltersToSpanAllOfToday(this.gridOptions.columnDefs[2].filters);
+    $scope.showOrdersDeliveredToday = () => setFiltersToSpanAllOfToday($scope.gridOptions.columnDefs[2].filters);
 });

--- a/src/web/js/controllers/admin/AdminOrdersController.js
+++ b/src/web/js/controllers/admin/AdminOrdersController.js
@@ -116,10 +116,16 @@ angular.module('cp.controllers.admin').controller('AdminOrdersController',
         enableFiltering: true,
         enableSorting: true,
         paginationPageSizes: [100, 200, 300],
-        paginationPageSize: 100
+        paginationPageSize: 100,
+        onRegisterApi(gridApi) {
+            $scope.gridApi = gridApi;
+            ClearAllButtonService.addToScopeUsingGridApi($scope, gridApi);
+        }
     };
 
-    ClearAllButtonService.addToScope($scope, vm.gridOptions);
+    $scope.getOrderNumbers = () => {
+        $scope.visibleOrderNumbers = $scope.gridApi.core.getVisibleRows().map(order => order.entity.humanId);
+    };
 
     function loadOrders() {
         OrdersFactory.getAllOrders().success(response => {

--- a/src/web/js/services/ClearAllButtonService.js
+++ b/src/web/js/services/ClearAllButtonService.js
@@ -4,6 +4,10 @@ angular.module('cp.services').service('ClearAllButtonService', function() {
             gridOptions.onRegisterApi = (gridApi) => {
                 scope.clearAllFilters = () => gridApi.grid.clearAllFilters();
             };
+        },
+
+        addToScopeUsingGridApi(scope, gridApi) {
+            scope.clearAllFilters = () => gridApi.grid.clearAllFilters();
         }
     };
 });

--- a/src/web/templates/admin/orders.html
+++ b/src/web/templates/admin/orders.html
@@ -7,6 +7,15 @@
         <button ng-click="showOrdersDeliveredToday()" class="show-orders-delivered-today btn btn-primary">Show orders delivered today</button>
         &nbsp;
         <button ng-click="clearAllFilters()" class="btn btn-primary">Clear all filters</button>
+        &nbsp;
+        <button ng-click="getOrderNumbers()" class="btn btn-primary">Get visible order numbers</button>
+    </p>
+
+    <p ng-if="visibleOrderNumbers !== undefined">
+        Visible order numbers:
+        {{ visibleOrderNumbers.join(', ') }}
+        <br />
+        (not auto updated when filters change)
     </p>
 
     <div ui-grid="gridOptions" ui-grid-pagination id="orders-table" style="height: 780px;"></div>

--- a/src/web/templates/admin/orders.html
+++ b/src/web/templates/admin/orders.html
@@ -9,5 +9,5 @@
         <button ng-click="clearAllFilters()" class="btn btn-primary">Clear all filters</button>
     </p>
 
-    <div ui-grid="orders.gridOptions" ui-grid-pagination id="orders-table" style="height: 780px;"></div>
+    <div ui-grid="gridOptions" ui-grid-pagination id="orders-table" style="height: 780px;"></div>
 </div>


### PR DESCRIPTION
This button is because I often spend time copying the visible order numbers into a comma-separated list. Having a button to get the order numbers saves time.

2483a3a711b99123de01a6b5337545b7d35c22e2 also standardises us on `$scope` (like almost every other controller) instead of `this`.

![image](https://cloud.githubusercontent.com/assets/398210/8063449/99fedb10-0ecc-11e5-856b-c53f5f3ddd5a.png)
