### PR TITLE
Create package: rename "add another address" button to "add first address" if none

### DIFF
--- a/src/web/templates/vendor/vendor-package.html
+++ b/src/web/templates/vendor/vendor-package.html
@@ -173,7 +173,11 @@
                     </div>
                 </div>
 
-                <button class="btn btn-primary" type="button" ng-click="addAnotherAddress()">Add another address</button>
+                <button class="btn btn-primary cp-add-vendor-address"
+                        type="button"
+                        ng-click="addAnotherAddress()">
+                    {{ vendor.addresses.length > 0 ? 'Add another address' : 'Add your first address' }}
+                </button>
             </fieldset>
         </div>
 

--- a/tests/e2e/vendor/CreatePackage.js
+++ b/tests/e2e/vendor/CreatePackage.js
@@ -75,7 +75,9 @@ describe('Vendor portal - create package', function() {
     });
 
     it('should be able to add an address', function() {
-        element(by.css('button[ng-click="addAnotherAddress()"]')).click();
+        var addAddressButton = element(by.css('button.cp-add-vendor-address'));
+        expect(addAddressButton.getText()).toBe('ADD ANOTHER ADDRESS');
+        addAddressButton.click();
 
         element(by.model('newAddress.addressLine1')).sendKeys('Francis House');
         element(by.model('newAddress.addressLine2')).sendKeys('11 Francis Street');
@@ -102,7 +104,7 @@ describe('Vendor portal - create package', function() {
     });
 
     it('should show an error if an invalid postcode is entered', function() {
-        element(by.css('button[ng-click="addAnotherAddress()"]')).click();
+        element(by.css('button.cp-add-vendor-address')).click();
         element(by.model('newAddress.postcode')).sendKeys('QWERTY');
         element(by.css('button[ng-click="addAddress()"]')).click();
 

--- a/tests/e2e/vendor/EditPackage.js
+++ b/tests/e2e/vendor/EditPackage.js
@@ -124,7 +124,9 @@ describe('Vendor portal - edit a non-meal-plan package', function() {
     // This test will fail if the suite is run in isolation because the address added by
     // CreatePackage will not exist.
     it('should be able to add an address', function() {
-        element(by.css('button[ng-click="addAnotherAddress()"]')).click();
+        var addAddressButton = element(by.css('button.cp-add-vendor-address'));
+        expect(addAddressButton.getText()).toBe('ADD ANOTHER ADDRESS');
+        addAddressButton.click();
 
         element(by.model('newAddress.addressLine1')).sendKeys('Jeremy House');
         element(by.model('newAddress.addressLine2')).sendKeys('22 Jeremy Road');
@@ -153,7 +155,7 @@ describe('Vendor portal - edit a non-meal-plan package', function() {
     });
 
     it('should show an error if an invalid postcode is entered', function() {
-        element(by.css('button[ng-click="addAnotherAddress()"]')).click();
+        element(by.css('button.cp-add-vendor-address')).click();
         element(by.model('newAddress.postcode')).sendKeys('QWERTY');
         element(by.css('button[ng-click="addAddress()"]')).click();
 


### PR DESCRIPTION
This is because vendors who use the new sign-up form will not have any address yet.

![image](https://cloud.githubusercontent.com/assets/398210/8376332/15fadcf8-1bfe-11e5-91ae-d0e597c4cb6c.png)