### PR TITLE
Refactor package display into cp-package-detail directive.

### DIFF
--- a/src/web/js/directives/cpPackageDetailDirective.js
+++ b/src/web/js/directives/cpPackageDetailDirective.js
@@ -1,0 +1,9 @@
+angular.module('cp').directive('cpPackageDetail', function(getTemplateUrl) {
+    return {
+        restrict: 'E',
+        scope: {
+            package: '='
+        },
+        templateUrl: getTemplateUrl('directives/cp-package-detail.html')
+    };
+});

--- a/src/web/scss/customer/order-leave-a-review.scss
+++ b/src/web/scss/customer/order-leave-a-review.scss
@@ -6,31 +6,6 @@
         left: auto;
     }
 
-    .cp-review-package {
-        @extend .row;
-        border: 5px solid $gray-light;
-        margin: 0 -20px;
-        padding: 20px 0;
-
-        > *[class^='col-'],
-        > *[class*=' col-'] {
-            padding: 0 20px;
-        }
-
-        > .right {
-            float: left;
-            margin-left: 20px;
-        }
-
-        h3 {
-            margin: 0 0 3px;
-        }
-
-        img {
-            float:left;
-        }
-    }
-
     .cp-star-rating-group {
         @extend .clearfix;
 
@@ -99,21 +74,4 @@
             float: right;
         }
     }
-}
-
-.cp-review-package-detail {
-    padding-left: 0 !important;
-}
-
-.cp-review-package-image {
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-size: cover;
-    height: 155px;
-}
-
-.cp-review-package-vendor-name,
-.cp-review-package-short-description {
-    font-size: 16px;
-    margin-bottom: $cp-margin-small-vertical;
 }

--- a/src/web/scss/directives/cp-package-detail.scss
+++ b/src/web/scss/directives/cp-package-detail.scss
@@ -1,0 +1,42 @@
+cp-package-detail {
+    display: block;
+    @extend .row;
+    border: 5px solid $gray-light;
+    margin: 0 -20px;
+    padding: 20px 0;
+
+    > *[class^='col-'],
+    > *[class*=' col-'] {
+        padding: 0 20px;
+    }
+
+    > .right {
+        float: left;
+        margin-left: 20px;
+    }
+
+    h3.cp-heading {
+        margin: 0 0 3px;
+    }
+
+    img {
+        float:left;
+    }
+}
+
+.cp-package-detail-right {
+    padding-left: 0 !important;
+}
+
+.cp-package-detail-image {
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 155px;
+}
+
+.cp-package-detail-vendor-name,
+.cp-package-detail-short-description {
+    font-size: 16px;
+    margin-bottom: $cp-margin-small-vertical;
+}

--- a/src/web/scss/main.scss
+++ b/src/web/scss/main.scss
@@ -936,6 +936,7 @@ hr {
 }
 
 @import 'directives/cp-package-card.scss';
+@import 'directives/cp-package-detail.scss';
 @import 'directives/cp-review-card.scss';
 @import 'directives/cp-dietary-requirements-form';
 @import 'directives/cp-review-meal-plan';

--- a/src/web/templates/customer/order-leave-a-review.html
+++ b/src/web/templates/customer/order-leave-a-review.html
@@ -4,20 +4,7 @@
         <span class="cp-light">{{ order.requestedDeliveryDate | date:'dd MMM yy' }}</span>
     </h2>
 
-    <div class="cp-review-package">
-        <div class="col-md-5">
-            <div class="cp-review-package-image" style="background-image: url('{{ order.package.images[0].thumbnail }}')"></div>
-        </div>
-        <div class="cp-review-package-detail col-md-7">
-            <h3 class="cp-heading">{{ order.package.name }}</h3>
-
-            <p class="cp-review-package-vendor-name">{{ order.package.vendor.name }}</p>
-
-            <p class="cp-review-package-short-description" ng-if="order.package.shortDescription" js-clamp="'3'">{{ order.package.shortDescription }}</p>
-
-            <a ng-href="/package/{{ order.package.humanId }}-{{ order.package.name | slugify }}" class="link-account">View details</a>
-        </div>
-    </div>
+    <cp-package-detail package="order.package"></cp-package-detail>
 
     <h2 class="cp-heading">Your feedback</h2>
 

--- a/src/web/templates/directives/cp-package-detail.html
+++ b/src/web/templates/directives/cp-package-detail.html
@@ -1,0 +1,13 @@
+<div class="col-md-5">
+    <div class="cp-package-detail-image" style="background-image: url('{{ package.images[0].thumbnail }}')"></div>
+</div>
+
+<div class="cp-package-detail-right col-md-7">
+    <h3 class="cp-heading">{{ package.name }}</h3>
+
+    <p class="cp-package-detail-vendor-name">{{ package.vendor.name }}</p>
+
+    <p class="cp-package-detail-short-description" ng-if="package.shortDescription" js-clamp="'3'">{{ package.shortDescription }}</p>
+
+    <a ng-href="/package/{{ package.humanId }}-{{ package.name | slugify }}" class="link-account">View details</a>
+</div>

--- a/tests/e2e/customer/OrderLeaveAReview.js
+++ b/tests/e2e/customer/OrderLeaveAReview.js
@@ -40,8 +40,8 @@ describe('Leaving a review for an order', function() {
     });
 
     it('should display the package details', function() {
-        expect(element(by.css('.cp-review-package h3')).getText()).toBe('BEEF AND MIXED VEG CURRY');
-        expect(element(by.css('.cp-review-package-vendor-name')).getText()).toBe('Oriental Kitchen Express');
+        expect(element(by.css('cp-package-detail h3')).getText()).toBe('BEEF AND MIXED VEG CURRY');
+        expect(element(by.css('.cp-package-detail-vendor-name')).getText()).toBe('Oriental Kitchen Express');
     });
 
     function getStar(parent, number) {


### PR DESCRIPTION
This is because this needs to be re-used in the new team pages.

![image](https://cloud.githubusercontent.com/assets/398210/8478741/328f735c-20cb-11e5-9fb1-d7a517465fae.png)
